### PR TITLE
Fix : correct version regexp to match complete revisions

### DIFF
--- a/update_spec.py
+++ b/update_spec.py
@@ -56,7 +56,7 @@ def get_current_spec_version(spec_file):
     with open(spec_file, "r") as f:
         spec_content = f.read()
 
-    version_regex = re.compile(r"^Version: ?([0-9\.\-]+)$", re.MULTILINE)
+    version_regex = re.compile(r"^Version: ?([0-9a-z\.\-]+)$", re.MULTILINE)
     version = version_regex.search(spec_content)
 
     if version is None or version.group(1) is None:


### PR DESCRIPTION
The last Vim releases have letters in their name. This breaks the SPEC file updater regex used to extract the `version` field.

This MR is updating the regexp to support this new format.

Antoine