### PR TITLE
Fix : correct spec version update regex

### DIFF
--- a/update_spec.py
+++ b/update_spec.py
@@ -90,7 +90,7 @@ def update_spec(version, spec, changelog):
     with open(spec, "r") as f:
         spec_content = f.read()
     logging.debug("Replacing version in spec file")
-    version_regex = re.compile(r"^(Version: ?)[0-9\.\-]+$", re.MULTILINE)
+    version_regex = re.compile(r"^(Version: ?)[0-9a-z\.\-]+$", re.MULTILINE)
     updated_spec = version_regex.sub(r"\g<1>{}".format(version), spec_content)
 
     logging.debug("Loading in memory file {}".format(changelog))


### PR DESCRIPTION
Following #1 , this MR is also fixing the regex used to update the spec file version to support versions named with letters.

[skip ci]