### PR TITLE
Switch to cinc-auditor for functionnal testing

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -108,12 +108,10 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:7
     needs: lint-rpm
-    env:
-      CHEF_LICENSE: "accept-silent"
     steps:
-      - name: Install inspec to run tests
+      - name: Install cinc-auditor to run tests
         run: |
-          curl https://omnitruck.chef.io/install.sh | bash -s -- -P inspec
+          curl -L https://omnitruck.cinc.sh/install.sh | sudo bash -s -- -P cinc-auditor -v 4
       - name: Fetch SCL RPM
         uses: actions/download-artifact@v2
         with:
@@ -130,7 +128,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run functionnal tests
         run: |
-          inspec exec tests/*.rb --chef-license accept-silent
+          cinc-auditor exec tests/*.rb
   create-release:
     runs-on: ubuntu-latest
     needs: rpm-functionnal-tests

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Install cinc-auditor to run tests
         run: |
-          curl -L https://omnitruck.cinc.sh/install.sh | sudo bash -s -- -P cinc-auditor -v 4
+          curl -L https://omnitruck.cinc.sh/install.sh | bash -s -- -P cinc-auditor -v 4
       - name: Fetch SCL RPM
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -108,6 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:7
     needs: lint-rpm
+    env:
+      CHEF_LICENSE: "accept-silent"
     steps:
       - name: Install inspec to run tests
         run: |
@@ -128,7 +130,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run functionnal tests
         run: |
-          inspec exec tests/*.rb --chef-license=accept-silent
+          inspec exec tests/*.rb --chef-license accept-silent
   create-release:
     runs-on: ubuntu-latest
     needs: rpm-functionnal-tests


### PR DESCRIPTION
To fix licence issues faced with Chef Inspec, this MR is transitioning the `rpm-functionnal-tests` task to CNCF backed `cinc-auditor`.

Antoine